### PR TITLE
ROOT scripts to average and print/draw results

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -20,3 +20,5 @@ n=$(ls -1 $base/*/$root|wc -l)
 
 # divide $sum to $n to get average and save results in the $root file
 scale -n $n -o $root $sum
+
+rm -f $sum

--- a/convert.sh
+++ b/convert.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+base="outfiles"
+# PHITS-generated output file name
+f=flux_at_the_end_of_chan.out
+# the corresponding ROOT file name
+root=${f%.out}.root
+
+# convert .out to .root
+parallel "cd {} && angel2root $f" ::: $base/*
+
+# temporary file name for the sum file
+sum=$(mktemp -u).root
+
+# sum results of all runs and save them into the $sum file
+hadd -f $sum $base/*/$root
+
+# number of ROOT files
+n=$(ls -1 $base/*/$root|wc -l)
+
+# divide $sum to $n to get average and save results in the $root file
+scale -n $n -o $root $sum

--- a/draw.py
+++ b/draw.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import sys
+import ROOT
+
+
+def main():
+    f = ROOT.TFile("flux_at_the_end_of_chan.root")
+    h = f.Get("h1")
+
+    val = h.GetBinContent(1)
+    err = h.GetBinError(1)
+
+    print(f"{val} ± {err}")
+
+    # uncomment to draw the histogram:
+    h.Draw("hist e")
+    input()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/draw.py
+++ b/draw.py
@@ -14,8 +14,8 @@ def main():
     print(f"{val} ± {err}")
 
     # uncomment to draw the histogram:
-    h.Draw("hist e")
-    input()
+    # h.Draw("hist e")
+    # input()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Usage:

1. Convert the PHITS-generated files into ROOT format: run `convert.sh`
2. Print the averaged value and optionally draw the histogram by running `python draw.py` (currently, the histogram has only one bin, so drawing it is not very meaningful, but it will be useful for histograms with multiple bins.)

The scripts need to have [GNU Parallel](https://www.gnu.org/software/parallel/), [ROOT](https://root.cern/) and [mc-tools](https://github.com/kbat/mc-tools) installed.

Install GNU Parallel in Linux: `apt install parallel`